### PR TITLE
Define HAD_JMP with semantics that clobber EFLAGS

### DIFF
--- a/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.h
+++ b/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.h
@@ -30,7 +30,11 @@ private:
   void EmitJump(MCStreamer &out, const MCInst &inst);
   void EmitReturn(MCStreamer &out, const MCInst &inst);
 
-  void EmitSafeBranch(MCStreamer &out, const MCInst &inst, unsigned targetReg, bool isCall);
+  void EmitSafeBranch(MCStreamer &out,
+                      const MCInst &inst,
+                      unsigned opcode,
+                      unsigned targetReg,
+                      bool alignToEnd);
 };
 
 }

--- a/lib/Target/X86/X86.h
+++ b/lib/Target/X86/X86.h
@@ -87,8 +87,8 @@ FunctionPass *createX86ExpandPseudoPass();
 FunctionPass *createX86FixupBWInsts();
 
 // @HADEAN@
-FunctionPass *createX86HadeanExpandJumps();
 FunctionPass *createX86HadeanRewriteControl();
+FunctionPass *createX86HadeanPreEmit();
 
 void initializeFixupBWInstPassPass(PassRegistry &);
 } // End llvm namespace

--- a/lib/Target/X86/X86HadeanRewriteControl.cpp
+++ b/lib/Target/X86/X86HadeanRewriteControl.cpp
@@ -68,7 +68,7 @@ bool X86HadeanRewriteControl::rewriteMI(MachineBasicBlock &MBB, MachineInstr &MI
 
   switch (MI.getOpcode()) {
    case X86::CALL64m:      newOpcode = X86::CALL64r;      regClass = &X86::GR64RegClass;    break;
-   case X86::JMP64m:       newOpcode = X86::JMP64r;       regClass = &X86::GR64RegClass;    break;
+   case X86::HAD_JMP64m:   newOpcode = X86::HAD_JMP64r;   regClass = &X86::GR64RegClass;    break;
    case X86::TCRETURNmi64: newOpcode = X86::TCRETURNri64; regClass = &X86::GR64_TCRegClass; break;
    default:                return false;
   }

--- a/lib/Target/X86/X86InstrControl.td
+++ b/lib/Target/X86/X86InstrControl.td
@@ -147,11 +147,11 @@ let isBranch = 1, isTerminator = 1, isBarrier = 1, isIndirectBranch = 1 in {
                    Requires<[Not64BitMode]>, OpSize32, Sched<[WriteJumpLd]>;
 
   def JMP64r     : I<0xFF, MRM4r, (outs), (ins GR64:$dst), "jmp{q}\t{*}$dst",
-                     [(brind GR64:$dst)], IIC_JMP_REG>, Requires<[In64BitMode]>,
+                     [(brind GR64:$dst)], IIC_JMP_REG>, Requires<[In64BitMode, NotHadean]>,
                    Sched<[WriteJump]>;
   def JMP64m     : I<0xFF, MRM4m, (outs), (ins i64mem:$dst), "jmp{q}\t{*}$dst",
                      [(brind (loadi64 addr:$dst))], IIC_JMP_MEM>,
-                   Requires<[In64BitMode]>, Sched<[WriteJumpLd]>;
+                   Requires<[In64BitMode, NotHadean]>, Sched<[WriteJumpLd]>;
 
   let Predicates = [Not64BitMode] in {
     def FARJMP16i  : Iseg16<0xEA, RawFrmImm16, (outs),

--- a/lib/Target/X86/X86InstrFormats.td
+++ b/lib/Target/X86/X86InstrFormats.td
@@ -56,11 +56,6 @@ def MRM_F9 : Format<89>; def MRM_FA : Format<90>; def MRM_FB : Format<91>;
 def MRM_FC : Format<92>; def MRM_FD : Format<93>; def MRM_FE : Format<94>;
 def MRM_FF : Format<95>;
 
-def CustomFrm : Format<126>; // @HADEAN@
-// We copy what NaCl does here. This presumably causes code emission to
-// fail if we accidentally fail to flatten one of our custom
-// instructions.
-
 // ImmType - This specifies the immediate type used by an instruction. This is
 // part of the ad-hoc solution used to emit machine instruction encodings by our
 // machine code emitter.

--- a/lib/Target/X86/X86InstrHadean.td
+++ b/lib/Target/X86/X86InstrHadean.td
@@ -1,0 +1,13 @@
+let Defs = [EFLAGS] in {
+  let isBranch = 1, isTerminator = 1, isBarrier = 1, isIndirectBranch = 1 in {
+    def HAD_JMP64r : I<0, MRM4r, (outs), (ins GR64:$dst), "hadjmp\t{*}$dst",
+                       [(brind GR64:$dst)], IIC_JMP_REG>, Requires<[In64BitMode, IsHadean]>,
+                     Sched<[WriteJump]>;
+
+    let isCodeGenOnly = 1 in {
+      def HAD_JMP64m : I<0, Pseudo, (outs), (ins i64mem:$dst), "",
+                         [(brind (loadi64 addr:$dst))], IIC_JMP_MEM>,
+                       Requires<[In64BitMode, IsHadean]>, Sched<[WriteJumpLd]>;
+    }
+  }
+}

--- a/lib/Target/X86/X86InstrInfo.td
+++ b/lib/Target/X86/X86InstrInfo.td
@@ -874,6 +874,8 @@ def IsPS4        : Predicate<"Subtarget->isTargetPS4()">;
 def NotPS4       : Predicate<"!Subtarget->isTargetPS4()">;
 def IsNaCl       : Predicate<"Subtarget->isTargetNaCl()">;
 def NotNaCl      : Predicate<"!Subtarget->isTargetNaCl()">;
+def IsHadean     : Predicate<"Subtarget->getTargetTriple().isVendorHadean()">;
+def NotHadean    : Predicate<"!Subtarget->getTargetTriple().isVendorHadean()">;
 def SmallCode    : Predicate<"TM.getCodeModel() == CodeModel::Small">;
 def KernelCode   : Predicate<"TM.getCodeModel() == CodeModel::Kernel">;
 def FarData      : Predicate<"TM.getCodeModel() != CodeModel::Small &&"
@@ -2561,6 +2563,9 @@ include "X86InstrSystem.td"
 
 // Compiler Pseudo Instructions and Pat Patterns
 include "X86InstrCompiler.td"
+
+// @HADEAN@
+include "X86InstrHadean.td"
 
 //===----------------------------------------------------------------------===//
 // Assembler Mnemonic Aliases

--- a/test/CodeGen/X86/Hadean/jump_flags.ll
+++ b/test/CodeGen/X86/Hadean/jump_flags.ll
@@ -1,0 +1,56 @@
+; Test that JMP semantics include clobbering EFLAGS.
+
+; RUN: llc -O2 -mtriple="x86_64-hadean-linux" -print-after-all < %s 2>&1 | FileCheck -check-prefix=CHECK-HADEAN %s
+; RUN: llc -O2 -mtriple="x86_64-unknown-linux" -print-after-all < %s 2>&1 | FileCheck -check-prefix=CHECK-LINUX %s
+
+declare i32 @bar(i32)
+
+define i32 @test(i32 %arg1, i32 %arg2, i32 %arg3)  {
+entry:
+  %cond1 = icmp eq i32 %arg1, 11
+
+  ; Dynamically generate a target basic block address. We define it here
+  ; rather than pass a pointer to the function to allow control-flow analysis.
+  %target = select i1 %cond1, i8* blockaddress(@test, %target1), i8* blockaddress(@test, %target2)
+
+  ; Branch code.
+  br i1 %cond1, label %left_branch, label %right_branch
+
+left_branch:
+  call i32 @bar(i32 99)                                  ; Side effects to prevent merging branches.
+
+  ; Generate a condition which can be carried to %target2 in EFLAGS.
+  %left_cond = icmp eq i32 %arg2, 55
+
+  ; Indirect branch to one of the targets.
+  indirectbr i8* %target, [ label %target1, label %target2 ]
+
+right_branch:
+  call i32 @bar(i32 88)                                  ; Side effects to prevent merging branches.
+  %right_cond = icmp eq i32 %arg3, 77
+  br label %target1
+
+target1:
+  %phi_cond1 = phi i1 [ %left_cond, %left_branch ], [ %right_cond, %right_branch ]
+  %result1 = select i1 %phi_cond1, i32 44, i32 66
+  ret i32 %result1
+
+target2:
+  ; This branch uses %left_cond defined in %left_branch. If `indirectbr` does not clobber
+  ; EFLAGS, LLVM's MachineCSE will avoid moving the flag to a register. On Hadean, this
+  ; does not hold and therefore a move is necessary.
+  %result2 = select i1 %left_cond, i32 144, i32 166
+  ret i32 %result2
+}
+
+; Compare the CFG on Linux vs Hadean.
+
+; CHECK-LINUX-LABEL:  IR Dump After StackMap Liveness Analysis
+; CHECK-LINUX:        derived from LLVM BB %target2
+; CHECK-LINUX-NEXT:   Live Ins: %EFLAGS
+; CHECK-LINUX-NEXT:   Predecessors according to CFG
+
+; CHECK-HADEAN-LABEL: IR Dump After StackMap Liveness Analysis
+; CHECK-HADEAN:       derived from LLVM BB %target2
+; CHECK-HADEAN-NOT:   Live Ins: %EFLAGS
+; CHECK-HADEAN:       Predecessors according to CFG


### PR DESCRIPTION
The previous implementation of Hadean CFI ignored the fact that
EFLAGS are clobbered by an indirect branch. We now define a custom
HAD_JMP pseudo-instruction with the correct semantics and forbid
selection of the standard JMP instructions.

We do not redefine CALL and RET despite the same applying to them,
because the calling convention states that EFLAGS are not preserved
across function calls.