### PR TITLE
Align jump table targets for Hadean CFI

### DIFF
--- a/lib/Target/X86/CMakeLists.txt
+++ b/lib/Target/X86/CMakeLists.txt
@@ -39,6 +39,7 @@ set(sources
   X86VZeroUpper.cpp
   X86WinAllocaExpander.cpp
   X86WinEHState.cpp
+  X86HadeanAlignCode.cpp # @HADEAN@
   X86HadeanRewriteControl.cpp # @HADEAN@
   )
 

--- a/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.cpp
+++ b/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.cpp
@@ -90,7 +90,7 @@ void HadeanExpander::EmitSafeBranch(MCStreamer &out,
   MCInstBuilder instAND(X86::AND64ri32);
   instAND.addReg(targetReg);
   instAND.addReg(targetReg);
-  instAND.addImm(-1);
+  instAND.addImm(-32);
   out.EmitInstruction(instAND, STI_);
 
   // Add the base from the reserved register.

--- a/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.cpp
+++ b/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.cpp
@@ -90,7 +90,7 @@ void HadeanExpander::EmitSafeBranch(MCStreamer &out,
   MCInstBuilder instAND(X86::AND64ri32);
   instAND.addReg(targetReg);
   instAND.addReg(targetReg);
-  instAND.addImm(-32);
+  instAND.addImm(-1);
   out.EmitInstruction(instAND, STI_);
 
   // Add the base from the reserved register.

--- a/lib/Target/X86/X86.h
+++ b/lib/Target/X86/X86.h
@@ -87,8 +87,8 @@ FunctionPass *createX86ExpandPseudoPass();
 FunctionPass *createX86FixupBWInsts();
 
 // @HADEAN@
+FunctionPass *createX86HadeanAlignCode();
 FunctionPass *createX86HadeanRewriteControl();
-FunctionPass *createX86HadeanPreEmit();
 
 void initializeFixupBWInstPassPass(PassRegistry &);
 } // End llvm namespace

--- a/lib/Target/X86/X86HadeanAlignCode.cpp
+++ b/lib/Target/X86/X86HadeanAlignCode.cpp
@@ -1,0 +1,59 @@
+#include <iterator>
+#include <cassert>
+#include "X86.h"
+#include "X86InstrBuilder.h"
+#include "X86Subtarget.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineJumpTableInfo.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/MC/MCContext.h"
+using namespace llvm;
+
+namespace {
+
+class X86HadeanAlignCode : public MachineFunctionPass {
+public:
+  static char ID;
+
+  X86HadeanAlignCode() : MachineFunctionPass(ID) {}
+  bool runOnMachineFunction(MachineFunction &fuction) override;
+  const char *getPassName() const override;
+};
+
+char X86HadeanAlignCode::ID = 0;
+
+}  // anonymous namespace
+
+const char *X86HadeanAlignCode::getPassName() const {
+    return "Hadean code alignment";
+}
+
+bool X86HadeanAlignCode::runOnMachineFunction(MachineFunction &MF) {
+  // Align function symbol. TODO: Only for taken MFs.
+  MF.setAlignment(5);
+
+  // Align basic blocks. TODO: Only for taken MBBs.
+  for (MachineBasicBlock &MBB : MF) {
+    MBB.setAlignment(5);
+  }
+
+  // Align jump table targets.
+  MachineJumpTableInfo *JTI = MF.getJumpTableInfo();
+  if (JTI != NULL) {
+    const std::vector<MachineJumpTableEntry> &JT = JTI->getJumpTables();
+    for (unsigned i = 0; i < JT.size(); ++i) {
+      const std::vector<MachineBasicBlock*> &MBBs = JT[i].MBBs;
+      for (unsigned j = 0; j < MBBs.size(); ++j) {
+        MBBs[j]->setAlignment(5);
+      }
+    }
+  }
+
+  return true;
+}
+
+FunctionPass *llvm::createX86HadeanAlignCode() {
+  return new X86HadeanAlignCode();
+}

--- a/lib/Target/X86/X86HadeanRewriteControl.cpp
+++ b/lib/Target/X86/X86HadeanRewriteControl.cpp
@@ -5,6 +5,7 @@
 #include "X86Subtarget.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineJumpTableInfo.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/MC/MCContext.h"
@@ -36,6 +37,18 @@ const char *X86HadeanRewriteControl::getPassName() const {
 bool X86HadeanRewriteControl::runOnMachineFunction(MachineFunction &MF) {
   // TODO: Do only for taken MFs.
   MF.setAlignment(5);
+
+  // Align jump table targets.
+  MachineJumpTableInfo *JTI = MF.getJumpTableInfo();
+  if (JTI != NULL) {
+    const std::vector<MachineJumpTableEntry> &JT = JTI->getJumpTables();
+    for (unsigned i = 0; i < JT.size(); ++i) {
+      const std::vector<MachineBasicBlock*> &MBBs = JT[i].MBBs;
+      for (unsigned j = 0; j < MBBs.size(); ++j) {
+        MBBs[j]->setAlignment(5);
+      }
+    }
+  }
 
   for (MachineBasicBlock &MBB : MF) {
     rewriteMBB(MBB);

--- a/lib/Target/X86/X86HadeanRewriteControl.cpp
+++ b/lib/Target/X86/X86HadeanRewriteControl.cpp
@@ -35,41 +35,27 @@ const char *X86HadeanRewriteControl::getPassName() const {
 }
 
 bool X86HadeanRewriteControl::runOnMachineFunction(MachineFunction &MF) {
-  // TODO: Do only for taken MFs.
-  MF.setAlignment(5);
-
-  // Align jump table targets.
-  MachineJumpTableInfo *JTI = MF.getJumpTableInfo();
-  if (JTI != NULL) {
-    const std::vector<MachineJumpTableEntry> &JT = JTI->getJumpTables();
-    for (unsigned i = 0; i < JT.size(); ++i) {
-      const std::vector<MachineBasicBlock*> &MBBs = JT[i].MBBs;
-      for (unsigned j = 0; j < MBBs.size(); ++j) {
-        MBBs[j]->setAlignment(5);
-      }
-    }
-  }
+  bool modified = false;
 
   for (MachineBasicBlock &MBB : MF) {
-    rewriteMBB(MBB);
+    modified |= rewriteMBB(MBB);
   }
 
-  return true;
+  return modified;
 }
 
 bool X86HadeanRewriteControl::rewriteMBB(MachineBasicBlock &MBB) {
-  // TODO: Do only for taken MBBs.
-  MBB.setAlignment(5);
+  bool modified = false;
 
   // MBBI may be invalidated by the expansion.
   MachineBasicBlock::iterator MBBIter = MBB.begin(), MBBEnd = MBB.end();
   while (MBBIter != MBBEnd) {
     const MachineBasicBlock::iterator MBBIterNext = std::next(MBBIter);
-    rewriteMI(MBB, *MBBIter);
+    modified |= rewriteMI(MBB, *MBBIter);
     MBBIter = MBBIterNext;
   }
 
-  return true;
+  return modified;
 }
 
 bool X86HadeanRewriteControl::rewriteMI(MachineBasicBlock &MBB, MachineInstr &MI) {

--- a/lib/Target/X86/X86TargetMachine.cpp
+++ b/lib/Target/X86/X86TargetMachine.cpp
@@ -335,4 +335,8 @@ void X86PassConfig::addPreEmitPass() {
     addPass(createX86PadShortFunctions());
     addPass(createX86FixupLEAs());
   }
+
+  if (Triple(TM->getTargetTriple()).isVendorHadean()) {
+    addPass(createX86HadeanAlignCode());
+  }
 }


### PR DESCRIPTION
LLVM previously wouldn't align the basic blocks of jump tables.