### PR TITLE
Instrument SYSCALLs

### DIFF
--- a/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.h
+++ b/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.h
@@ -29,6 +29,7 @@ private:
   void EmitIndirectCall(MCStreamer &out, const MCInst &inst);
   void EmitJump(MCStreamer &out, const MCInst &inst);
   void EmitReturn(MCStreamer &out, const MCInst &inst);
+  void EmitSyscall(MCStreamer &out, const MCInst &inst);
 
   void EmitSafeBranch(MCStreamer &out,
                       const MCInst &inst,

--- a/test/MC/X86/Hadean/syscall.s
+++ b/test/MC/X86/Hadean/syscall.s
@@ -4,3 +4,11 @@
   mov $60, %rax
   syscall
   hlt
+
+// CHECK:      {{^\.text:}}
+// CHECK-NEXT:   movq    $60, %rax
+// CHECK-NEXT:   movabsq $0, %rcx
+// CHECK-NEXT:   nopl
+// CHECK-NEXT:   nopw    -83(%rsi,%rbx,8)
+// CHECK-NEXT:   syscall
+// CHECK-NEXT:   hlt

--- a/test/MC/X86/Hadean/syscall.s
+++ b/test/MC/X86/Hadean/syscall.s
@@ -1,21 +1,6 @@
-// RUN: llvm-mc -assemble -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
-
-.section .data
-
-some_var1:     .long 1234
-some_var2:     .long 5678
-__hadean_host: .long 0
+// RUN: llvm-mc -assemble -hadean-debug-cfi=false -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
 
 .section .text
-
-.global __hadean_syscall
-.type   __hadean_syscall, @function
-__hadean_syscall:
-  ret
-
-.global test
-.type   test, @function
-test:
   mov $60, %rax
   syscall
   hlt

--- a/test/MC/X86/Hadean/syscall.s
+++ b/test/MC/X86/Hadean/syscall.s
@@ -1,0 +1,21 @@
+// RUN: llvm-mc -assemble -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
+
+.section .data
+
+some_var1:     .long 1234
+some_var2:     .long 5678
+__hadean_host: .long 0
+
+.section .text
+
+.global __hadean_syscall
+.type   __hadean_syscall, @function
+__hadean_syscall:
+  ret
+
+.global test
+.type   test, @function
+test:
+  mov $60, %rax
+  syscall
+  hlt


### PR DESCRIPTION
Instruments SYSCALL instructions with a NOP marker that is recognized
by elf2hoff and later replaced with a JMP to a Hadean syscall handler.
It also stores the return address into RCX, otherwise clobbered register.