### PR TITLE
Experimental implementation of MPX

### DIFF
--- a/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -437,7 +437,7 @@ public:
   HadeanX86_64AsmBackend(const Target &T, uint8_t OSABI, StringRef CPU)
     : ELFX86_64AsmBackend(T, OSABI, CPU),
       STI_(X86_MC::createX86MCSubtargetInfo(Triple("x86_64", "unknown", "hadean"), CPU, "")),
-      expander_(*STI_) {}
+      expander_(*STI_, std::unique_ptr<MCInstrInfo>(T.createMCInstrInfo())) {}
 
   bool customExpandInst(const MCInst &instr, MCStreamer &out) override {
     out.EmitBundleAlignMode(HadeanExpander::kBundleSizeInBits);  // TODO: move to MCStreamer init

--- a/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.cpp
+++ b/lib/Target/X86/MCTargetDesc/X86MCHadeanExpander.cpp
@@ -12,7 +12,18 @@
 #include <llvm/MC/MCSubtargetInfo.h>
 #include "MCTargetDesc/X86MCTargetDesc.h"
 
+#define GET_INSTRINFO_OPERAND_TYPES_ENUM
+#include "X86GenInstrInfo.inc"
+
 namespace llvm {
+
+cl::opt<bool> EnableCFI("hadean-cfi",
+                        cl::desc("Hadean CFI assembly instrumentation"),
+                        cl::init(true));
+
+cl::opt<bool> EnableMPX("hadean-mpx",
+                        cl::desc("Hadean MPX assembly instrumentation"),
+                        cl::init(false));
 
 // To enable, pass '-mllvm --hadean-debug-cfi' to Clang.
 // TODO: This is enaled by default for now. Disable before putting into production!.
@@ -20,120 +31,419 @@ cl::opt<bool> DebugCFI("hadean-debug-cfi",
                        cl::desc("Debug instrumentation for Hadean CFI"),
                        cl::init(true));
 
-bool HadeanExpander::expandInstruction(MCStreamer &out, const MCInst &inst) {
-  // If this is a recursive expansion of `inst`, return immediately.
-  if (emitRaw_) {
+extern const char X86InstrNameData[];
+extern const unsigned X86InstrNameIndices[];
+
+static constexpr unsigned kReadOnlyBoundsReg = X86::BND2;
+static constexpr unsigned kReadWriteBoundsReg = X86::BND3;
+static constexpr unsigned kStackOpBoundsReg = kReadWriteBoundsReg;
+
+static const char *GetName(const MCInst &inst) {
+  return &X86InstrNameData[X86InstrNameIndices[inst.getOpcode()]];
+}
+
+const MCInstrDesc &HadeanExpander::GetDesc(const MCInst &inst) {
+  return II_->get(inst.getOpcode());
+}
+
+static inline bool IsMemoryOperand(const MCInstrDesc &desc, unsigned opIndexMC) {
+  return desc.OpInfo[opIndexMC].OperandType == MCOI::OPERAND_MEMORY;
+}
+
+static inline bool IsStackRegisterOperand(const MCInst &inst, unsigned opIndexMC) {
+  const MCOperand &operand = inst.getOperand(opIndexMC);
+  return operand.isReg() && (operand.getReg() == X86::RSP ||
+                             operand.getReg() == X86::ESP ||
+                             operand.getReg() == X86::SP  ||
+                             operand.getReg() == X86::SPL);
+}
+
+static inline bool IsPrefixInstruction(const MCInst &inst) {
+  switch (inst.getOpcode()) {
+  case X86::CS_PREFIX:
+  case X86::DATA16_PREFIX:
+  case X86::DS_PREFIX:
+  case X86::ES_PREFIX:
+  case X86::FS_PREFIX:
+  case X86::GS_PREFIX:
+  case X86::LOCK_PREFIX:
+  case X86::REPNE_PREFIX:
+  case X86::REP_PREFIX:
+  case X86::REX64_PREFIX:
+  case X86::SS_PREFIX:
+  case X86::XACQUIRE_PREFIX:
+  case X86::XRELEASE_PREFIX:
+    return true;
+  default:
     return false;
   }
+}
 
-  switch (inst.getOpcode()) {
-    case X86::CALL64pcrel32: EmitDirectCall(out, inst);   break;
-    case X86::CALL64r:       EmitIndirectCall(out, inst); break;
-    case X86::HAD_JMP64r:
-    case X86::TAILJMPr64:    EmitJump(out, inst);         break;
-    case X86::RETQ:          EmitReturn(out, inst);       break;
-    case X86::SYSCALL:       EmitSyscall(out, inst);      break;
+struct MemoryOperand {
+  MemoryOperand() : valid(false) {}
 
-    case X86::JMP64r:
-    case X86::JMP64m:
-      report_fatal_error("Found indirect 'jmp' instrution. Use 'had_jmp' instead");
-
-    case X86::CALL64m:
-    case X86::HAD_JMP64m:
-      report_fatal_error("Instruction should have been expanded");
-
-    default:
-      return false;
+  void FromInst(const MCInst &inst, unsigned opIndexMC, int64_t offset) {
+    base = inst.getOperand(opIndexMC + 0).getReg();
+    scale = inst.getOperand(opIndexMC + 1).getImm();
+    index = inst.getOperand(opIndexMC + 2).getReg();
+    displacement = inst.getOperand(opIndexMC + 3).getImm() + offset;
+    segment = inst.getOperand(opIndexMC + 4).getReg();
+    valid = true;
   }
 
+  void FromStackPtr(int64_t offset) {
+    base = X86::RSP;
+    scale = 1;
+    index = 0;
+    displacement = offset;
+    segment = 0;
+    valid = true;
+  }
+
+  void AppendTo(MCInstBuilder &builder) const {
+    // ModRM can encode 1, 2 or 4 byte displacements.
+    static constexpr int64_t kMinModRmDisplacement = std::numeric_limits<int32_t>::min();
+    static constexpr int64_t kMaxModRmDisplacement = std::numeric_limits<int32_t>::max();
+
+    if (displacement < kMinModRmDisplacement || kMaxModRmDisplacement < displacement) {
+      // TODO: Handle large displacements.
+      report_fatal_error("Displacement too large to encode");
+    }
+
+    builder.addReg(base);
+    builder.addImm(scale);
+    builder.addReg(index);
+    builder.addImm(displacement);
+    builder.addReg(segment);
+  }
+
+  bool IsValid() const { return valid; }
+
+  bool valid;
+
+  unsigned base;
+  int64_t scale;
+  unsigned index;
+  int64_t displacement;
+  unsigned segment;
+};
+
+static inline bool IsPush(const MCInst &inst, /* out */ int64_t *outSize = nullptr) {
+  int64_t size;
+  switch (inst.getOpcode()) {
+    case X86::PUSH16r:
+    case X86::PUSH16rmr: size = 2; break;
+
+    case X86::PUSH64r:
+    case X86::PUSH64rmr: size = 8; break;
+
+    case X86::PUSH64i8:  size = 1; break;
+    case X86::PUSH64i32: size = 4; break;
+
+    case X86::PUSH16rmm:
+    case X86::PUSH64rmm: report_fatal_error("PUSH from memory not valid on Hadean");
+
+    case X86::PUSH32r:
+    case X86::PUSH32rmr:
+    case X86::PUSH32rmm: report_fatal_error("PUSH32 not valid on x86_64");
+
+    default:             return false;
+  }
+
+  if (outSize != nullptr) {
+    *outSize = size;
+  }
   return true;
 }
 
-void HadeanExpander::EmitJump(MCStreamer &out, const MCInst& inst) {
-  assert(inst.getOpcode() == X86::HAD_JMP64r || inst.getOpcode() == X86::TAILJMPr64);
-  assert(inst.getNumOperands() == 1);
-  assert(inst.getOperand(0).isReg());
-  EmitSafeBranch(
-      out, inst, /* opcode */ X86::JMP64r, inst.getOperand(0).getReg(), /* alignToEnd */ false);
-}
+static inline bool IsPop(const MCInst &inst, /* out */ int64_t *outSize = nullptr) {
+  int64_t size;
+  switch (inst.getOpcode()) {
+    case X86::POP16r:
+    case X86::POP16rmr: size = 2; break;
 
-void HadeanExpander::EmitDirectCall(MCStreamer &out, const MCInst &inst) {
-  assert(inst.getOpcode() == X86::CALL64pcrel32);
+    case X86::POP64r:
+    case X86::POP64rmr: size = 8; break;
 
-  out.EmitBundleLock(/* alignToEnd */ true);
-  emitRaw_ = true; out.EmitInstruction(inst, STI_); emitRaw_ = false;
-  out.EmitBundleUnlock();
-}
+    case X86::POP16rmm:
+    case X86::POP64rmm: report_fatal_error("POP from memory not valid on Hadean");
 
-void HadeanExpander::EmitIndirectCall(MCStreamer &out, const MCInst &inst) {
-  assert(inst.getOpcode() == X86::CALL64r);
-  assert(inst.getNumOperands() == 1);
-  assert(inst.getOperand(0).isReg());
-  EmitSafeBranch(
-      out, inst, /* opcode */ X86::CALL64r, inst.getOperand(0).getReg(), /* alignToEnd */ true);
-}
+    case X86::POP32r:
+    case X86::POP32rmr:
+    case X86::POP32rmm: report_fatal_error("POP32 not valid on x86_64");
 
-void HadeanExpander::EmitReturn(MCStreamer &out, const MCInst &inst) {
-  assert(inst.getOpcode() == X86::RETQ);
-  static constexpr unsigned kTempReg = X86::R11;  // register not preserved across function calls
-
-  MCInstBuilder instPOP(X86::POP64r);
-  instPOP.addReg(kTempReg);
-  out.EmitInstruction(instPOP, STI_);
-
-  MCInstBuilder instJMP(X86::JMP64r);
-  instJMP.addReg(kTempReg);
-  EmitSafeBranch(out, instJMP, /* opcode */ X86::JMP64r, kTempReg, /* alignToEnd */ false);
-}
-
-void HadeanExpander::EmitSafeBranch(MCStreamer &out,
-                                    const MCInst &inst,
-                                    unsigned opcode,
-                                    unsigned targetReg,
-                                    bool alignToEnd) {
-  if (DebugCFI) {
-    // Do an AND $31 on `targetReg`. Trap if the bottom five bits are not zero.
-    MCContext &context = out.getContext();
-    MCSymbol *labelFine = context.createTempSymbol();
-    out.EmitInstruction(MCInstBuilder(X86::PUSH64r).addReg(targetReg), STI_);
-    out.EmitInstruction(MCInstBuilder(X86::AND64ri32).addReg(targetReg).addReg(targetReg).addImm(31), STI_);
-    out.EmitInstruction(MCInstBuilder(X86::JE_4).addExpr(MCSymbolRefExpr::create(labelFine, context)), STI_);
-    out.EmitInstruction(MCInstBuilder(X86::TRAP), STI_);
-    out.EmitLabel(labelFine);
-    out.EmitInstruction(MCInstBuilder(X86::POP64r).addReg(targetReg), STI_);
+    default:          return false;
   }
 
-  out.EmitBundleLock(alignToEnd);
-
-  // Mask out bottom bits of the pointer. The immediate will be replaced
-  // by elf2hoff to mask out the top bits as well.
-  MCInstBuilder instAND(X86::AND64ri32);
-  instAND.addReg(targetReg);
-  instAND.addReg(targetReg);
-  instAND.addImm(-32);
-  out.EmitInstruction(instAND, STI_);
-
-  // Add the base from the reserved register.
-  MCInstBuilder instLEA(X86::LEA64r);
-  instLEA.addReg(targetReg);
-  instLEA.addReg(kCodeBaseRegister);
-  instLEA.addImm(1);
-  instLEA.addReg(targetReg);
-  instLEA.addImm(0);
-  instLEA.addReg(0);
-  out.EmitInstruction(instLEA, STI_);
-
-  // Emit the branch instruction
-  MCInstBuilder instBranch(opcode);
-  instBranch.addReg(targetReg);
-  emitRaw_ = true; out.EmitInstruction(instBranch, STI_); emitRaw_ = false;
-
-  out.EmitBundleUnlock();
+  if (outSize != nullptr) {
+    *outSize = size;
+  }
+  return true;
 }
 
-void HadeanExpander::EmitSyscall(MCStreamer &out, const MCInst &instSYSCALL) {
-  assert(instSYSCALL.getOpcode() == X86::SYSCALL);
-  // TODO: FIX LOCK PREFIX ON THE SYSCALL
+static inline unsigned GetMemoryOperandSize(const MCInst &inst, unsigned opIdxGen) {
+  for (auto& entry : X86::OpTypes::InstOpInfoArray) {
+    if (entry.Opcode == inst.getOpcode()) {
+      switch (entry.OperandTypes[opIdxGen]) {
+      case X86::OpTypes::i8mem:   return 1;
+      case X86::OpTypes::i16mem:  return 2;
+      case X86::OpTypes::f32mem:
+      case X86::OpTypes::i32mem:  return 4;
+      case X86::OpTypes::f64mem:
+      case X86::OpTypes::i64mem:  return 8;
+      case X86::OpTypes::f80mem:  return 10;
+      case X86::OpTypes::f128mem:
+      case X86::OpTypes::i128mem: return 16;
+      case X86::OpTypes::f256mem:
+      case X86::OpTypes::i256mem: return 32;
+      case X86::OpTypes::f512mem:
+      case X86::OpTypes::i512mem: return 64;
+      default:
+        report_fatal_error(std::string("Operand #") + std::to_string(opIdxGen) + " of instruction "
+                           + GetName(inst) + " is not a recognized memory operand type");
+      }
+    }
+  }
+  report_fatal_error(std::string("Could not find operand type info for opcode ") + GetName(inst));
+}
+
+bool HadeanExpander::expandInstruction(MCStreamer &out, const MCInst &inst) {
+  assert(!frames_.empty());
+
+  WorkFrame &current = frames_.back();
+  if (current.stage_ == kEmitStage) {
+    return false;
+  }
+
+  if (IsPrefixInstruction(inst)) {
+    current.prefixes_.append({ inst });
+    return true;
+  }
+
+  Stage stage = current.stage_;
+  PrefixInst p_inst(inst, current.prefixes_);
+  current.prefixes_.clear();
+
+  while (true) {
+    bool handled = false;
+
+    frames_.push_back(WorkFrame(static_cast<Stage>(stage + 1)));
+    switch (stage) {
+    case kHadeanJumpStage:
+      handled = HandleHadeanJump(out, p_inst);
+      break;
+    case kMpxMemAccessStage:
+      handled = HandleMPX_MemoryAccess(out, p_inst);
+      break;
+    case kMpxStackPtrStage:
+      handled = HandleMPX_StackPtrUpdate(out, p_inst);
+      break;
+    case kCfiStage:
+      handled = HandleCFI(out, p_inst);
+      break;
+    case kSyscallStage:
+      handled = HandleSyscall(out, p_inst);
+      break;
+    default:
+      report_fatal_error("Unexpected");
+    }
+    frames_.pop_back();
+
+    if (handled) {
+      return true;
+    }
+
+    stage = static_cast<Stage>(stage + 1);
+
+    if (stage == kEmitStage) {
+      if (p_inst.prefixes_.empty()) {
+        return false;
+      } else {
+        frames_.push_back(WorkFrame(kEmitStage));
+        EmitWithPrefixes(out, p_inst);
+        frames_.pop_back();
+        return true;
+      }
+    }
+  }
+}
+
+void HadeanExpander::EmitWithPrefixes(MCStreamer &out, const PrefixInst &p_inst) {
+  if (p_inst.prefixes_.empty()) {
+    out.EmitInstruction(p_inst.inst_, STI_);
+  } else {
+    out.EmitBundleLock(/* alignToEnd */ false);
+    for (auto &prefix : p_inst.prefixes_) {
+      out.EmitInstruction(prefix, STI_);
+    }
+    out.EmitInstruction(p_inst.inst_, STI_);
+    out.EmitBundleUnlock();
+  }
+}
+
+bool HadeanExpander::HandleHadeanJump(MCStreamer &out, const PrefixInst &p_inst) {
+  switch (p_inst.inst_.getOpcode()) {
+    case X86::HAD_JMP64r: {
+      MCInstBuilder instJMP(X86::JMP64r);
+      instJMP.addReg(p_inst.inst_.getOperand(0).getReg());
+      EmitWithPrefixes(out, PrefixInst(instJMP, p_inst));
+      return true;
+    }
+
+    case X86::JMP64r:
+    case X86::JMP64m:
+      // This method is not invoked recursively on the lowered JMP instruction.
+      // If we're seeing a JMP, it is coming from user's code.
+      report_fatal_error("Found indirect 'jmp' instrution. Use 'hadjmp' instead");
+
+    case X86::CALL64m:
+      report_fatal_error("Found indirect 'call' with a memory operand. "
+                         "Use the variant with a register operand instead");
+
+    case X86::HAD_JMP64m:
+      report_fatal_error("Found indirect 'hadjmp' with a memory operand. "
+                         "Use the variant with a register operand instead");
+
+    default: {
+      return false;
+    }
+  }
+}
+
+bool HadeanExpander::HandleMPX_StackPtrUpdate(MCStreamer &out, const PrefixInst &p_inst) {
+  if (!EnableMPX) {
+    return false;
+  }
+
+  const MCInstrDesc &desc = GetDesc(p_inst.inst_);
+
+  bool foundStackPtrDef = false;
+  for (unsigned i = 0; i < desc.getNumDefs(); ++i) {
+    if (IsStackRegisterOperand(p_inst.inst_, i)) {
+      assert(!foundStackPtrDef);
+      foundStackPtrDef = true;
+    }
+  }
+
+  if (foundStackPtrDef) {
+    // Emit the original instruction, allowing it to update RSP, then check
+    // the value is within bounds.
+
+    out.EmitBundleLock(/* alignToEnd */ false);
+
+    EmitWithPrefixes(out, p_inst);
+
+    MCInstBuilder instLower(X86::BNDCL64rr);
+    instLower.addReg(kStackOpBoundsReg);
+    instLower.addReg(X86::RSP);
+    out.EmitInstruction(instLower, STI_);
+
+    MCInstBuilder instUpper(X86::BNDCU64rr);
+    instUpper.addReg(kStackOpBoundsReg);
+    instUpper.addReg(X86::RSP);
+    out.EmitInstruction(instUpper, STI_);
+
+    out.EmitBundleUnlock();
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool HadeanExpander::HandleMPX_MemoryAccess(MCStreamer &out, const PrefixInst &p_inst) {
+  if (!EnableMPX) {
+    return false;
+  }
+
+  const MCInstrDesc &desc = GetDesc(p_inst.inst_);
+  if (!desc.mayLoad() && !desc.mayStore()) {
+    return false;
+  }
+
+  int64_t size;
+  unsigned boundsReg;
+  MemoryOperand memAddrLower, memAddrUpper;
+
+  if (IsPush(p_inst.inst_, &size)) {
+    boundsReg = kStackOpBoundsReg;
+    memAddrLower.FromStackPtr(-size);
+  } else if (IsPop(p_inst.inst_, &size)) {
+    boundsReg = kStackOpBoundsReg;
+    memAddrUpper.FromStackPtr(size);
+  } else {
+    boundsReg = desc.mayStore() ? kReadWriteBoundsReg : kReadOnlyBoundsReg;
+    // Iterate over all operands. Because memory operands are expanded to five
+    // machine operands, we keep two indices, one into the high-level instruction
+    // description and one into the MCInst operands list.
+    for (unsigned idxMC = 0, idxGen = 0; idxMC < desc.getNumOperands(); ++idxMC, ++idxGen) {
+      if (IsMemoryOperand(desc, idxMC)) {
+        assert(!memAddrLower.IsValid() && !memAddrUpper.IsValid() && "Multiple memory operands");
+        unsigned operandSize = GetMemoryOperandSize(p_inst.inst_, idxGen);
+        memAddrLower.FromInst(p_inst.inst_, idxMC, 0);
+        memAddrUpper.FromInst(p_inst.inst_, idxMC, operandSize - 1);
+        idxMC += 4;
+      }
+    }
+  }
+
+  if (!memAddrLower.IsValid() && !memAddrUpper.IsValid()) {
+    switch (p_inst.inst_.getOpcode()) {
+    case X86::INT3:
+    case X86::PAUSE:
+    case X86::TRAP:
+      return false;
+    default:
+      report_fatal_error(std::string("Instruction ") + GetName(p_inst.inst_) +
+                         " with load/store semantics without a memory operand");
+    }
+  }
+
+  out.EmitBundleLock(/* alignToEnd */ false);
+
+  if (memAddrLower.IsValid()) {
+    MCInstBuilder instLower(X86::BNDCL64rm);
+    instLower.addReg(boundsReg);
+    memAddrLower.AppendTo(instLower);
+    out.EmitInstruction(instLower, STI_);
+  }
+
+  if (memAddrUpper.IsValid()) {
+    MCInstBuilder instUpper(X86::BNDCU64rm);
+    instUpper.addReg(boundsReg);
+    memAddrUpper.AppendTo(instUpper);
+    out.EmitInstruction(instUpper, STI_);
+  }
+
+  EmitWithPrefixes(out, p_inst);
+  out.EmitBundleUnlock();
+  return true;
+}
+
+bool HadeanExpander::HandleCFI(MCStreamer &out, const PrefixInst &p_inst) {
+  if (!EnableCFI) {
+    return false;
+  }
+
+  switch (p_inst.inst_.getOpcode()) {
+    case X86::CALL64pcrel32: EmitDirectCall(out, p_inst);   break;
+    case X86::CALL64r:       EmitIndirectCall(out, p_inst); break;
+    case X86::JMP64r:
+    case X86::TAILJMPr64:    EmitJump(out, p_inst);         break;
+    case X86::RETQ:          EmitReturn(out, p_inst);       break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+bool HadeanExpander::HandleSyscall(MCStreamer &out, const PrefixInst &p_inst) {
+  if (p_inst.inst_.getOpcode() != X86::SYSCALL) {
+    return false;
+  }
+
+  if (!p_inst.prefixes_.empty()) {
+    report_fatal_error("Cannot handle SYSCALL instruction with prefixes");
+  }
 
   // We instrument the SYSCALL instruction with a 6-byte NOP. This way, elf2hoff
   // has enough space to replace the 2-byte SYSCALL with a 5-byte direct JMP with
@@ -170,6 +480,113 @@ void HadeanExpander::EmitSyscall(MCStreamer &out, const MCInst &instSYSCALL) {
   // Return label
   out.EmitCodeAlignment(kBundleSizeInBytes);
   out.EmitLabel(labelReturn);
+  return true;
+}
+
+void HadeanExpander::EmitJump(MCStreamer &out, const PrefixInst &p_inst) {
+  assert(p_inst.inst_.getOpcode() == X86::JMP64r || p_inst.inst_.getOpcode() == X86::TAILJMPr64);
+  assert(p_inst.inst_.getNumOperands() == 1);
+  assert(p_inst.inst_.getOperand(0).isReg());
+  EmitSafeBranch(
+      out, p_inst, /* opcode */ X86::JMP64r, p_inst.inst_.getOperand(0).getReg(), /* alignToEnd */ false);
+}
+
+void HadeanExpander::EmitDirectCall(MCStreamer &out, const PrefixInst &p_inst) {
+  assert(p_inst.inst_.getOpcode() == X86::CALL64pcrel32);
+
+  out.EmitBundleLock(/* alignToEnd */ true);  // CALLs must be at the end of a bundle
+  EmitWithPrefixes(out, p_inst);
+  out.EmitBundleUnlock();
+}
+
+void HadeanExpander::EmitIndirectCall(MCStreamer &out, const PrefixInst &p_inst) {
+  assert(p_inst.inst_.getOpcode() == X86::CALL64r);
+  assert(p_inst.inst_.getNumOperands() == 1);
+  assert(p_inst.inst_.getOperand(0).isReg());
+  EmitSafeBranch(
+      out, p_inst, /* opcode */ X86::CALL64r, p_inst.inst_.getOperand(0).getReg(), /* alignToEnd */ true);
+}
+
+void HadeanExpander::EmitReturn(MCStreamer &out, const PrefixInst &p_inst) {
+  assert(p_inst.inst_.getOpcode() == X86::RETQ);
+  static constexpr unsigned kTempReg = X86::R11;  // register not preserved across function calls
+
+  MCInstBuilder instPOP(X86::POP64r);
+  instPOP.addReg(kTempReg);
+  out.EmitInstruction(instPOP, STI_);
+
+  MCInstBuilder instJMP(X86::JMP64r);
+  instJMP.addReg(kTempReg);
+  EmitSafeBranch(out, PrefixInst(instJMP, p_inst), /* opcode */ X86::JMP64r, kTempReg, /* alignToEnd */ false);
+}
+
+void HadeanExpander::EmitSafeBranch(MCStreamer &out,
+                                    const PrefixInst &p_inst,
+                                    unsigned opcode,
+                                    unsigned targetReg,
+                                    bool alignToEnd) {
+  if (DebugCFI) {
+    // Do an AND $31 on `targetReg`. Trap if the bottom five bits are not zero.
+    MCContext &context = out.getContext();
+    MCSymbol *labelFine = context.createTempSymbol();
+
+    // Backup the target register.
+    MCInstBuilder instPUSH(X86::PUSH64r);
+    instPUSH.addReg(targetReg);
+    out.EmitInstruction(instPUSH, STI_);
+
+    // Mask out all but the bottom bits that should be zero.
+    MCInstBuilder instAND(X86::AND64ri32);
+    instAND.addReg(targetReg);
+    instAND.addReg(targetReg);
+    instAND.addImm(kBundleSizeInBytes - 1);
+    out.EmitInstruction(instAND, STI_);
+
+    // Skip over the TRAP if the zero flag is set.
+    MCInstBuilder instSKIP(X86::JE_4);
+    instSKIP.addExpr(MCSymbolRefExpr::create(labelFine, context));
+    out.EmitInstruction(instSKIP, STI_);
+
+    // If not zero, trap.
+    out.EmitInstruction(MCInstBuilder(X86::TRAP), STI_);
+
+    // Target of skipping the TRAP instruction.
+    out.EmitLabel(labelFine);
+
+    // Restore the clobbered target register.
+    MCInstBuilder instPOP(X86::POP64r);
+    instPOP.addReg(targetReg);
+    out.EmitInstruction(instPOP, STI_);
+  }
+
+  {
+    out.EmitBundleLock(alignToEnd);
+
+    // Mask out bottom bits of the pointer. The immediate will be replaced
+    // by elf2hoff to mask out the top bits as well.
+    MCInstBuilder instAND(X86::AND64ri32);
+    instAND.addReg(targetReg);
+    instAND.addReg(targetReg);
+    instAND.addImm(-kBundleSizeInBytes);
+    out.EmitInstruction(instAND, STI_);
+
+    // Add the base from the reserved register.
+    MCInstBuilder instLEA(X86::LEA64r);
+    instLEA.addReg(targetReg);
+    instLEA.addReg(kCodeBaseRegister);
+    instLEA.addImm(1);
+    instLEA.addReg(targetReg);
+    instLEA.addImm(0);
+    instLEA.addReg(0);
+    out.EmitInstruction(instLEA, STI_);
+
+    // Emit the branch instruction
+    MCInstBuilder instBranch(opcode);
+    instBranch.addReg(targetReg);
+    out.EmitInstruction(instBranch, STI_);
+
+    out.EmitBundleUnlock();
+  }
 }
 
 }  // namespace llvm

--- a/lib/Target/X86/X86HadeanRewriteControl.cpp
+++ b/lib/Target/X86/X86HadeanRewriteControl.cpp
@@ -68,6 +68,10 @@ bool X86HadeanRewriteControl::rewriteMI(MachineBasicBlock &MBB, MachineInstr &MI
   switch (MI.getOpcode()) {
    case X86::CALL64m:      newOpcode = X86::CALL64r;      regClass = &X86::GR64RegClass;    break;
    case X86::HAD_JMP64m:   newOpcode = X86::HAD_JMP64r;   regClass = &X86::GR64RegClass;    break;
+   case X86::POP16rmm:     newOpcode = X86::POP16r;       regClass = &X86::GR64RegClass;    break;
+   case X86::POP64rmm:     newOpcode = X86::POP64r;       regClass = &X86::GR64RegClass;    break;
+   case X86::PUSH16rmm:    newOpcode = X86::PUSH16r;      regClass = &X86::GR64RegClass;    break;
+   case X86::PUSH64rmm:    newOpcode = X86::PUSH64r;      regClass = &X86::GR64RegClass;    break;
    case X86::TCRETURNmi64: newOpcode = X86::TCRETURNri64; regClass = &X86::GR64_TCRegClass; break;
    default:                return false;
   }

--- a/lib/Target/X86/X86InstrInfo.cpp
+++ b/lib/Target/X86/X86InstrInfo.cpp
@@ -357,9 +357,9 @@ X86InstrInfo::X86InstrInfo(X86Subtarget &STI)
     { X86::MUL8r,       X86::MUL8m,         TB_FOLDED_LOAD },
     { X86::PEXTRDrr,    X86::PEXTRDmr,      TB_FOLDED_STORE },
     { X86::PEXTRQrr,    X86::PEXTRQmr,      TB_FOLDED_STORE },
-    { X86::PUSH16r,     X86::PUSH16rmm,     TB_FOLDED_LOAD },
-    { X86::PUSH32r,     X86::PUSH32rmm,     TB_FOLDED_LOAD },
-    { X86::PUSH64r,     X86::PUSH64rmm,     TB_FOLDED_LOAD },
+    { X86::PUSH16r,     X86::PUSH16rmm,     static_cast<uint16_t>(TB_FOLDED_LOAD | NoForwardForHadean) }, // @HADEAN@
+    { X86::PUSH32r,     X86::PUSH32rmm,     static_cast<uint16_t>(TB_FOLDED_LOAD | NoForwardForHadean) }, // @HADEAN@
+    { X86::PUSH64r,     X86::PUSH64rmm,     static_cast<uint16_t>(TB_FOLDED_LOAD | NoForwardForHadean) }, // @HADEAN@
     { X86::SETAEr,      X86::SETAEm,        TB_FOLDED_STORE },
     { X86::SETAr,       X86::SETAm,         TB_FOLDED_STORE },
     { X86::SETBEr,      X86::SETBEm,        TB_FOLDED_STORE },

--- a/lib/Target/X86/X86MCInstLower.cpp
+++ b/lib/Target/X86/X86MCInstLower.cpp
@@ -597,6 +597,12 @@ ReSimplify:
   case X86::RELEASE_DEC32m:    OutMI.setOpcode(X86::DEC32m); goto ReSimplify;
   case X86::RELEASE_DEC64m:    OutMI.setOpcode(X86::DEC64m); goto ReSimplify;
 
+  // @HADEAN@
+  // These should not reach the assembler and should be lowered to their
+  // standard counterparts.
+  case X86::MOV8mr_NOREX: OutMI.setOpcode(X86::MOV8mr); goto ReSimplify;
+  case X86::MOV8rm_NOREX: OutMI.setOpcode(X86::MOV8rm); goto ReSimplify;
+
   // We don't currently select the correct instruction form for instructions
   // which have a short %eax, etc. form. Handle this by custom lowering, for
   // now.
@@ -604,9 +610,7 @@ ReSimplify:
   // Note, we are currently not handling the following instructions:
   // MOV64ao8, MOV64o8a
   // XCHG16ar, XCHG32ar, XCHG64ar
-  case X86::MOV8mr_NOREX:
   case X86::MOV8mr:
-  case X86::MOV8rm_NOREX:
   case X86::MOV8rm:
   case X86::MOV16mr:
   case X86::MOV16rm:

--- a/test/CodeGen/X86/Hadean/call.ll
+++ b/test/CodeGen/X86/Hadean/call.ll
@@ -15,7 +15,6 @@ define i8* @test(i64 %a, i64 %b, i64 %c, i64 %d, i64 %e, i64 %f, void ()* %targe
 ; CHECK-IR:        CALL64m
 
 ; CHECK-ASM:       movq    {{[0-9]+}}(%rsp), %[[REG:r..]]
-; CHECK-ASM-NEXT:  nopw
-; CHECK-ASM-NEXT:  andq    $-32, %[[REG]]
+; CHECK-ASM:       andq    $-32, %[[REG]]
 ; CHECK-ASM-NEXT:  leaq    (%r15,%[[REG]]), %[[REG]]
 ; CHECK-ASM-NEXT:  callq   *%[[REG]]

--- a/test/CodeGen/X86/Hadean/call_rel.ll
+++ b/test/CodeGen/X86/Hadean/call_rel.ll
@@ -20,4 +20,4 @@ define void @test() {
 ; CHECK-ASM:       nop{{[w]?}}
 ; CHECK-ASM:       callq  {{[-0-9]+}} <foo>
 ; CHECK-ASM-NOT:   nop{{[w]?}}
-; CHECK-ASM:       jmpq
+; CHECK-ASM:       popq

--- a/test/MC/X86/Hadean/mem_load.s
+++ b/test/MC/X86/Hadean/mem_load.s
@@ -1,0 +1,75 @@
+// RUN: llvm-mc -hadean-mpx=true -assemble -mcpu=knl -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
+
+.text
+
+// ====== 8-BIT VALUE ======
+
+andb 44(%rdx), %al
+
+// CHECK:      bndcl  44(%rdx), %bnd2
+// CHECK-NEXT: bndcu  44(%rdx), %bnd2
+// CHECK-NEXT: andb   44(%rdx), %al
+
+// ====== 16-BIT VALUE ======
+
+andw -1234(%rbx,%rcx), %ax
+
+// CHECK:      bndcl  -1234(%rbx,%rcx), %bnd2
+// CHECK-NEXT: bndcu  -1233(%rbx,%rcx), %bnd2
+// CHECK-NEXT: andw   -1234(%rbx,%rcx), %ax
+
+// ====== 32-BIT VALUE ======
+
+andl -1234(%rbx,%rcx,2), %eax
+
+// CHECK:      bndcl  -1234(%rbx,%rcx,2), %bnd2
+// CHECK-NEXT: bndcu  -1231(%rbx,%rcx,2), %bnd2
+// CHECK-NEXT: andl   -1234(%rbx,%rcx,2), %eax
+
+// ====== 32-BIT FLOAT VALUE ======
+
+movss (%rax), %xmm0
+
+// CHECK:      bndcl  (%rax), %bnd2
+// CHECK-NEXT: bndcu  3(%rax), %bnd2
+// CHECK-NEXT: movss (%rax), %xmm0
+
+// ====== 64-BIT VALUE ======
+
+andq -1234(%rbx,%rcx,4), %rax
+
+// CHECK:      bndcl  -1234(%rbx,%rcx,4), %bnd2
+// CHECK-NEXT: bndcu  -1227(%rbx,%rcx,4), %bnd2
+// CHECK-NEXT: andq   -1234(%rbx,%rcx,4), %rax
+
+// ====== 64-BIT FLOAT VALUE ======
+
+movsd 32(%rcx), %xmm1
+
+// CHECK:      bndcl  32(%rcx), %bnd2
+// CHECK-NEXT: bndcu  39(%rcx), %bnd2
+// CHECK-NEXT: movsd  32(%rcx), %xmm1
+
+// ====== 80-BIT FLOAT VALUE ======
+
+fldt 64(%rax)
+
+// CHECK:      bndcl  64(%rax), %bnd2
+// CHECK-NEXT: bndcu  73(%rax), %bnd2
+// CHECK-NEXT: fldt   64(%rax)
+
+// ====== 128-BIT FLOAT VALUE ======
+
+movaps 256(%rbx), %xmm0
+
+// CHECK:      bndcl  256(%rbx), %bnd2
+// CHECK-NEXT: bndcu  271(%rbx), %bnd2
+// CHECK-NEXT: movaps 256(%rbx), %xmm0
+
+// ====== 512-BIT VALUE ======
+
+vmovdqa64 16(%rdx), %zmm19
+
+// CHECK:      bndcl  16(%rdx), %bnd2
+// CHECK-NEXT: bndcu  79(%rdx), %bnd2
+// CHECK-NEXT: vmovdqa64 16(%rdx), %zmm19

--- a/test/MC/X86/Hadean/mem_store.s
+++ b/test/MC/X86/Hadean/mem_store.s
@@ -1,0 +1,75 @@
+// RUN: llvm-mc -hadean-mpx=true -assemble -mcpu=knl -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
+
+.text
+
+// ====== 8-BIT VALUE ======
+
+andb %al, 44(%rdx)
+
+// CHECK:      bndcl  44(%rdx), %bnd3
+// CHECK-NEXT: bndcu  44(%rdx), %bnd3
+// CHECK-NEXT: andb   %al, 44(%rdx)
+
+// ====== 16-BIT VALUE ======
+
+andw %ax, -1234(%rbx,%rcx)
+
+// CHECK:      bndcl  -1234(%rbx,%rcx), %bnd3
+// CHECK-NEXT: bndcu  -1233(%rbx,%rcx), %bnd3
+// CHECK-NEXT: andw   %ax, -1234(%rbx,%rcx)
+
+// ====== 32-BIT VALUE ======
+
+andl %eax, -1234(%rbx,%rcx,2)
+
+// CHECK:      bndcl  -1234(%rbx,%rcx,2), %bnd3
+// CHECK-NEXT: bndcu  -1231(%rbx,%rcx,2), %bnd3
+// CHECK-NEXT: andl   %eax, -1234(%rbx,%rcx,2)
+
+// ====== 32-BIT FLOAT VALUE ======
+
+movss %xmm0, (%rax)
+
+// CHECK:      bndcl  (%rax), %bnd3
+// CHECK-NEXT: bndcu  3(%rax), %bnd3
+// CHECK-NEXT: movss %xmm0, (%rax)
+
+// ====== 64-BIT VALUE ======
+
+andq %rax, -1234(%rbx,%rcx,4)
+
+// CHECK:      bndcl  -1234(%rbx,%rcx,4), %bnd3
+// CHECK-NEXT: bndcu  -1227(%rbx,%rcx,4), %bnd3
+// CHECK-NEXT: andq   %rax, -1234(%rbx,%rcx,4)
+
+// ====== 64-BIT FLOAT VALUE ======
+
+movsd %xmm1, 32(%rcx)
+
+// CHECK:      bndcl  32(%rcx), %bnd3
+// CHECK-NEXT: bndcu  39(%rcx), %bnd3
+// CHECK-NEXT: movsd  %xmm1, 32(%rcx)
+
+// ====== 80-BIT FLOAT VALUE ======
+
+fstpt 64(%rax)
+
+// CHECK:      bndcl  64(%rax), %bnd3
+// CHECK-NEXT: bndcu  73(%rax), %bnd3
+// CHECK-NEXT: fstpt  64(%rax)
+
+// ====== 128-BIT FLOAT VALUE ======
+
+movaps %xmm0, 256(%rbx)
+
+// CHECK:      bndcl  256(%rbx), %bnd3
+// CHECK-NEXT: bndcu  271(%rbx), %bnd3
+// CHECK-NEXT: movaps %xmm0, 256(%rbx)
+
+// ====== 512-BIT VALUE ======
+
+vmovdqa64 %zmm19, 16(%rdx)
+
+// CHECK:      bndcl  16(%rdx), %bnd3
+// CHECK-NEXT: bndcu  79(%rdx), %bnd3
+// CHECK-NEXT: vmovdqa64 %zmm19, 16(%rdx)

--- a/test/MC/X86/Hadean/no_cfi_hadjmp.s
+++ b/test/MC/X86/Hadean/no_cfi_hadjmp.s
@@ -1,0 +1,9 @@
+// RUN: llvm-mc --hadean-cfi=false -assemble -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
+
+// Test that hadjmp is replaced with jmp when CFI disabled
+
+.text
+  hadjmp *%rax
+
+// CHECK-NOT: hadjmp
+// CHECK:     jmpq *%rax

--- a/test/MC/X86/Hadean/prefix.s
+++ b/test/MC/X86/Hadean/prefix.s
@@ -1,0 +1,13 @@
+// RUN: llvm-mc -hadean-mpx=true -assemble -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
+
+// LLVM treats instruction prefixes as separate instructions. We need to make sure
+// that our instrumentation does not split the prefix from the instruction it modifies.
+
+.text
+  lock
+  orl $0, (%rsp)
+
+// CHECK:      bndcl
+// CHECK-NEXT: bndcu
+// CHECK-NEXT: lock
+// CHECK-NEXT: orl

--- a/test/MC/X86/Hadean/stack-pop-mem-fail.s
+++ b/test/MC/X86/Hadean/stack-pop-mem-fail.s
@@ -1,0 +1,5 @@
+// RUN: llvm-mc -assemble -triple=x86_64-unknown-linux -filetype obj < %s > /dev/null
+// RUN: not llvm-mc -hadean-mpx=true -assemble -triple=x86_64-hadean-linux -filetype obj < %s > /dev/null
+
+.text
+popq 16(%rdx)

--- a/test/MC/X86/Hadean/stack-push-mem-fail.s
+++ b/test/MC/X86/Hadean/stack-push-mem-fail.s
@@ -1,0 +1,5 @@
+// RUN: llvm-mc -assemble -triple=x86_64-unknown-linux -filetype obj < %s > /dev/null
+// RUN: not llvm-mc -hadean-mpx=true -assemble -triple=x86_64-hadean-linux -filetype obj < %s > /dev/null
+
+.text
+pushq 16(%rdx)

--- a/test/MC/X86/Hadean/stack.s
+++ b/test/MC/X86/Hadean/stack.s
@@ -1,0 +1,72 @@
+// RUN: llvm-mc -hadean-mpx=true -assemble -triple=x86_64-hadean-linux -filetype obj < %s | llvm-objdump -d - | FileCheck %s
+
+.text
+
+// ====== PUSH 16-BIT REGISTER ======
+
+pushw %dx
+
+// CHECK:      bndcl  -2(%rsp), %bnd3
+// CHECK-NEXT: pushw  %dx
+
+// ====== PUSH 64-BIT REGISTER ======
+
+pushq %rdx
+
+// CHECK:      bndcl  -8(%rsp), %bnd3
+// CHECK-NEXT: pushq  %rdx
+
+// ====== POP 16-BIT REGISTER ======
+
+popw %dx
+
+// CHECK:      bndcu  2(%rsp), %bnd3
+// CHECK-NEXT: popw   %dx
+
+// ====== POP 64-BIT REGISTER ======
+
+popq %rdx
+
+// CHECK:      bndcu  8(%rsp), %bnd3
+// CHECK-NEXT: popq   %rdx
+
+// ====== SET SPL REGISTER ======
+
+andb $42, %spl
+
+// CHECK:      andb $42, %spl
+// CHECK-NEXT: bndcl %rsp, %bnd3
+// CHECK-NEXT: bndcu %rsp, %bnd3
+
+// ====== SET SP REGISTER ======
+
+andw $1234, %sp
+
+// CHECK:      andw $1234, %sp
+// CHECK-NEXT: bndcl %rsp, %bnd3
+// CHECK-NEXT: bndcu %rsp, %bnd3
+
+// ====== SET ESP REGISTER ======
+
+andl $65000, %esp
+
+// CHECK:      andl $65000, %esp
+// CHECK-NEXT: bndcl %rsp, %bnd3
+// CHECK-NEXT: bndcu %rsp, %bnd3
+
+// ====== SET RSP REGISTER ======
+
+andq $65535, %rsp
+
+// CHECK:      andq $65535, %rsp
+// CHECK-NEXT: bndcl %rsp, %bnd3
+// CHECK-NEXT: bndcu %rsp, %bnd3
+
+// ====== POP INTO RSP REGISTER ======
+
+popq %rsp
+
+// CHECK:      bndcu 8(%rsp), %bnd3
+// CHECK-NEXT: popq %rsp
+// CHECK-NEXT: bndcl %rsp, %bnd3
+// CHECK-NEXT: bndcu %rsp, %bnd3

--- a/utils/TableGen/InstrInfoEmitter.cpp
+++ b/utils/TableGen/InstrInfoEmitter.cpp
@@ -316,7 +316,7 @@ void InstrInfoEmitter::emitOperandTypesEnum(raw_ostream &OS,
                                             const CodeGenTarget &Target) {
 
   StringRef Namespace = Target.getInstNamespace();
-  std::vector<Record *> Operands = Records.getAllDerivedDefinitions("Operand");
+  std::vector<Record *> Operands = Records.getAllDerivedDefinitions("DAGOperand");
 
   OS << "#ifdef GET_INSTRINFO_OPERAND_TYPES_ENUM\n";
   OS << "#undef GET_INSTRINFO_OPERAND_TYPES_ENUM\n";
@@ -333,6 +333,37 @@ void InstrInfoEmitter::emitOperandTypesEnum(raw_ostream &OS,
   }
 
   OS << "  OPERAND_TYPE_LIST_END" << "\n};\n";
+
+  unsigned MaxNumOperands = 0;
+  for (const CodeGenInstruction *Inst : Target.getInstructionsByEnumValue()) {
+    MaxNumOperands = std::max(MaxNumOperands, Inst->Operands.size());
+  }
+
+  OS << "\nstruct InstOpInfo {\n";
+  OS << "  unsigned Opcode;\n";
+  OS << "  OperandType OperandTypes[" << MaxNumOperands << "];\n";
+  OS << "};\n\n";
+  OS << "static const InstOpInfo InstOpInfoArray[] = {\n";
+
+  for (const CodeGenInstruction *Inst : Target.getInstructionsByEnumValue()) {
+    if (Inst->isCodeGenOnly) {
+      continue;
+    }
+
+    OS << "  { " << Target.getName() << "::" << Inst->TheDef->getName() << ", { ";
+    bool isFirst = true;
+    for (auto &Op : Inst->Operands) {
+      if (isFirst) {
+        isFirst = false;
+      } else {
+        OS << ", ";
+      }
+      OS << Op.Rec->getNameInitAsString();
+    }
+    OS << " } },\n";
+  }
+  OS << "};\n";
+
   OS << "} // end namespace OpTypes\n";
   OS << "} // end namespace " << Namespace << "\n";
   OS << "} // end namespace llvm\n";


### PR DESCRIPTION
Adds a new system of passes in HadeanExpander which allows to
selectively enable/disable different expansions, and implements
two passes which instrument memory access instructions and stack
pointer changing instructions with MPX bound checks.